### PR TITLE
Abort and print error stack in case something goes wrong

### DIFF
--- a/cli/bittrex_closed_positions.js
+++ b/cli/bittrex_closed_positions.js
@@ -84,7 +84,7 @@ BittrexManager.getOrderHistory()
     console.log(otherTable.toString());
   })
   .catch((err) => {
-    console.log(err);
+    console.log(err.error.stack);
   })
 
 

--- a/lib/bittrex_manager.js
+++ b/lib/bittrex_manager.js
@@ -16,6 +16,11 @@ const BittrexManager = function BittrexManager({}) {
 BittrexManager.prototype.getTotalDeposits = function() {
   return new Promise((resolve, reject) => {
     this.api.getdeposithistory({}, (err, data) => {
+      if (err) {
+        console.log(err.error.stack);
+        return;
+      }
+
       if (data.success) {
         const output = data.result.map((deposit) => {
           return {


### PR DESCRIPTION
Due to environment variables and proxy settings, I was getting an error
when running a couple of scripts (closed positions and total deposits).

I noticed the code was not aborting (return) when an error happened on the
network, so I decided to add the code to handle errors in the promise callback